### PR TITLE
Solve the `FROM UNNEST(...)` issue

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,3 +34,7 @@ Breaking the line in which the expression is found would solve this issue. But t
 there's no other reason why the line should be broken.
 
 ![broken line](img/04_broken_line.png)
+
+This issue is resolved in [4][1].
+
+[1]: https://github.com/daczarne/vscode-language-sql-bigquery/pull/4

--- a/syntaxes/sql-bigquery.tmLanguage.json
+++ b/syntaxes/sql-bigquery.tmLanguage.json
@@ -83,7 +83,7 @@
           "name": "variable.parameter.table.partition_decorator.legacy.sql"
         }
       },
-      "match": "(?i)(from|join|delete\\s+from|delete(?!\\s+from)|update|using)\\s+((`?)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?(?:INFORMATION_SCHEMA\\.\\w+|[\\w\\{\\}\\.\\(\\=\\\"\\'\\-\\,\\s\\)]+))(\\*|\\$\\w+)?\\3?|\\[((?:[\\w\\-\\{\\}]+(?:\\:|(\\.)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\])",
+      "match": "(?i)(from(?!\\s+unnest)|join|delete\\s+from|delete(?!\\s+from)|update|using)\\s+((`?)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?(?:INFORMATION_SCHEMA\\.\\w+|[\\w\\{\\}\\.\\(\\=\\\"\\'\\-\\,\\s\\)]+))(\\*|\\$\\w+)?\\3?|\\[((?:[\\w\\-\\{\\}]+(?:\\:|(\\.)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\])",
       "name": "meta.create.from.sql"
     },
     {


### PR DESCRIPTION
This issue is farily straightforward to solve. All we need to add is a negative lookahead to the start of the regex. If the keyword `UNNEST` is found immediatly after the `FROM` keyword then the matching stops. At this point the matching for the `UNNEST` (function) segment starts.